### PR TITLE
Fix: used the os module to prompt a directory change for accessing the README.md file

### DIFF
--- a/Khronos/setup.py
+++ b/Khronos/setup.py
@@ -1,13 +1,13 @@
 import setuptools
-import os
 
-os.chdir("../")
+with open(r'..\README.md', "r") as file:
+  long_desc = file.read()
 
 setuptools.setup(
     name="django-khronos",
     version="0.1.1",
     description="Khronos is a Python library that benchmarks the duration of Django tests. It helps identify slow-running tests in your test suite, allowing you to optimize their performance.",
-    long_description=open("README.md").read(),
+    long_description=long_desc,
     long_description_content_type="text/markdown",
     author="Abhinav Prakash",
     author_email="abhinavsp0730@gmail.com",

--- a/Khronos/setup.py
+++ b/Khronos/setup.py
@@ -1,4 +1,7 @@
 import setuptools
+import os
+
+os.chdir("../")
 
 setuptools.setup(
     name="django-khronos",


### PR DESCRIPTION
## What changes does this PR introduce?

A single line of code is added 
```python 
os.chdir('../')
``` 
This changes the **current directory** to **parent**, therefore, making the README.md file accessible while preserving the current files execution.

Fix #5 